### PR TITLE
Pclouds 1597 create job for azure functions tests fails

### DIFF
--- a/deployment/dynatrace-azure-forwarder.json
+++ b/deployment/dynatrace-azure-forwarder.json
@@ -381,7 +381,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "DYNATRACE_URL",


### PR DESCRIPTION
Azure Function runtime version 3 is deprecated, so
updating default runtime version (4) for azure log forwarder as well