### PR TITLE
PCLOUDS-2747 Making sure we close each opened connection

### DIFF
--- a/host.json
+++ b/host.json
@@ -11,5 +11,13 @@
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 3.0.0)"
-  }
+  },
+   "extensions": {
+        "eventHubs": {
+            "initialOffsetOptions": {
+                "type": "fromEnd",
+                "enqueuedTimeUtc": ""
+            }
+        }
+    }
 }

--- a/logs_ingest/self_monitoring.py
+++ b/logs_ingest/self_monitoring.py
@@ -64,7 +64,8 @@ class SelfMonitoring:
                 resource_id = os.environ.get("RESOURCE_ID", None)
                 region = os.environ.get("REGION", None)
                 if not resource_id or not region:
-                    logging.info("Please set RESOURCE_ID and REGION in application settings to send self monitoring metrics to Azure")
+                    logging.info(
+                        "Please set RESOURCE_ID and REGION in application settings to send self-monitoring metrics to Azure")
                     return
                 resource_id = resource_id[1:] if resource_id.startswith('/') else resource_id
                 url = f"https://{region}.monitoring.azure.com/{resource_id}/metrics"
@@ -76,15 +77,17 @@ class SelfMonitoring:
 
                 metric_name = self_monitoring_metric.get("data", "").get("baseData", "").get("metric", "")
                 try:
-                    urllib.request.urlopen(req)
-                    logging.debug(f'Successfully sent self monitoring metric ({metric_name}) to Azure')
+                    with urllib.request.urlopen(req) as response:
+                        response.read()  # Read the response data (optional)
+                    logging.debug(f'Successfully sent self-monitoring metric ({metric_name}) to Azure')
                 except HTTPError as e:
                     logging.exception(
-                        f'Failed to push self monitoring metric ({metric_name}) to Azure: {e.code}, reason: {e.reason}", url: {url}',
+                        f'Failed to push self-monitoring metric ({metric_name}) to Azure: {e.code}, reason: {e.reason}", url: {url}',
                         "sfm-push-http-exception")
                 except Exception as e:
-                    logging.exception(f"Failed to push self monitoring metric ({metric_name}) to Azure. Reason is {type(e).__name__} {e}",
-                                      "sfm-push-failure-exception")
+                    logging.exception(
+                        f"Failed to push self-monitoring metric ({metric_name}) to Azure. Reason is {type(e).__name__} {e}",
+                        "sfm-push-failure-exception")
 
     def prepare_metric_data(self):
         time = self.execution_time.isoformat() + "Z"

--- a/logs_ingest/self_monitoring.py
+++ b/logs_ingest/self_monitoring.py
@@ -78,7 +78,7 @@ class SelfMonitoring:
                 metric_name = self_monitoring_metric.get("data", "").get("baseData", "").get("metric", "")
                 try:
                     with urllib.request.urlopen(req) as response:
-                        response.read()  # Read the response data (optional)
+                        response.read()
                     logging.debug(f'Successfully sent self-monitoring metric ({metric_name}) to Azure')
                 except HTTPError as e:
                     logging.exception(


### PR DESCRIPTION
Changes:
- Start the end of eventhub, not start
- make sure to close each request while pushing self-monitoring metrics