### PR TITLE
Fix webapp deployment src parameter

### DIFF
--- a/deployment/dynatrace-azure-logs.sh
+++ b/deployment/dynatrace-azure-logs.sh
@@ -447,7 +447,7 @@ echo "- deploying function zip code into ${FUNCTIONAPP_NAME}..."
 
 sleep 60 # wait some time to allow functionapp to warmup
 
-az webapp deploy -n ${FUNCTIONAPP_NAME} -g ${RESOURCE_GROUP} --src ${FUNCTION_ZIP_PACKAGE}
+az webapp deploy -n ${FUNCTIONAPP_NAME} -g ${RESOURCE_GROUP} --src-path ${FUNCTION_ZIP_PACKAGE}
 
 if [[ "$ENABLE_USER_ASSIGNED_MANAGED_IDENTITY" == "true" ]]; then
   MANAGED_IDENTITY_RESOURCE_ID=$(az identity show --name ${MANAGED_IDENTITY_RESOURCE_NAME} -g ${RESOURCE_GROUP} --query id --output tsv)


### PR DESCRIPTION
The `az webapp deploy` command update in f8b973b267d9143775160363b463aa1ef18b07cf needed to change the `--src` parameter to `--src-path`, otherwise users receive the error `ambiguous option: --src could match --src-path, --src-url` and the code deployment fails.

Successfully tested this change.