### PR TITLE
Update extensions bundles versions to supported versions

### DIFF
--- a/host.json
+++ b/host.json
@@ -10,7 +10,7 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.3.0, 4.0.0)"
+    "version": "[4.0.0, 5.0.0)"
   },
    "extensions": {
         "eventHubs": {


### PR DESCRIPTION
extension bundles 3.x.x are deprecated, update to supported version:
https://learn.microsoft.com/en-us/azure/azure-functions/extension-bundles