### PR TITLE
Update Travis build environment distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-dist: focal
+dist: noble
 language: shell
 if: fork = false
 notifications:


### PR DESCRIPTION
Updated Travis environment distribution to get rid of build errors 
`E: The repository 'http://apt.postgresql.org/pub/repos/apt focal-pgdg Release' no longer has a Release file.`